### PR TITLE
add fullscreen to base app

### DIFF
--- a/views/main.jade
+++ b/views/main.jade
@@ -5,6 +5,8 @@ block vars
 doctype html
 html
     head
+    meta(name='apple-mobile-web-app-capable', content='yes')
+    meta(name='mobile-web-app-capable', content='yes')
         +defaultHead()
         block head
 


### PR DESCRIPTION
This feature allows iOS and Android devices to open the web application
in fullscreen mode, if it was launched from a desktop icon shortcut
like native applications