### PR TITLE
add viewport scale 1

### DIFF
--- a/views/main.jade
+++ b/views/main.jade
@@ -7,6 +7,7 @@ html
     head
     meta(name='apple-mobile-web-app-capable', content='yes')
     meta(name='mobile-web-app-capable', content='yes')
+    meta(name='viewport', content='width=device-width, initial-scale=1.0, user-scalable=no')
         +defaultHead()
         block head
 


### PR DESCRIPTION
To view web apps at the same size as the desktop, apply a scale
relative to the resolution of the mobile device. It makes the app look
like it was designed for a mobile device, when displayed on a mobile
device.