### PR TITLE
actions - enabling based on properties of current entity row

### DIFF
--- a/public/assets/js/allcount.js
+++ b/public/assets/js/allcount.js
@@ -682,7 +682,7 @@ allcountModule.directive("lcActions", ["rest", "messages", "$parse", "$modal", f
                     scope.actions = [];
                 } else {
                     var entityCrudId = scope.entityCrudId;
-                    rest.actions(scope.entityCrudId, scope.actionTarget).then(function (actions) {
+                    rest.actions(scope.entityCrudId, scope.actionTarget, scope.selectedItems).then(function (actions) {
                         scope.actions = _.map(actions, function (action) {
                             action.perform = function () {
                                 action.isPerforming = true;

--- a/routes/actions-route.js
+++ b/routes/actions-route.js
@@ -2,7 +2,7 @@ module.exports = function (actionService, routeUtil) {
     return {
         actionList: function (req, res) {
             actionService
-                .actionListFor(routeUtil.extractEntityCrudId(req), req.query.actionTarget).then(function (actions) { return res.json(actions) }).done();
+                .actionListFor(routeUtil.extractEntityCrudId(req), req.query.actionTarget, JSON.parse(req.query.selectedItemIds)).then(function (actions) { return res.json(actions) }).done();
         },
         performAction: function (req, res) {
             actionService.performAction(routeUtil.extractEntityCrudId(req), req.params.actionId, req.body.selectedItemIds).then(function (actionResult) {


### PR DESCRIPTION
Added support for action context in enabled function. Now it is possible to enable action basing on current entity object properties.

Sample code using this feature (action will be enabled only when status of current entity equals 'Status1':
```
actions: [
            {
              id: 'cancel',
              name: 'Cancel',
              actionTarget: 'single-item',
              perform: function (Crud, Actions,) {
                ...
              },
              enabled: function (Crud, Actions) {
                var crud = Crud.crudForEntityType('SampleEntity');                
                return crud.readEntity(Actions.selectedEntityId()).then(function (entity) {
                  return entity.status == 'Status1' ? true : false;                  
                })
              },
            }
]
```