### PR TITLE
entity actions - hiding based on properties of current entity row

### DIFF
--- a/services/action-service.js
+++ b/services/action-service.js
@@ -30,8 +30,13 @@ module.exports = function (entityDescriptionService, injection, appUtil) {
                         },
                         isEnabled: function (selectedItemIds) {
                             return Q(action.hasPropertyValue('enabled') ? invokeProperty(selectedItemIds, function () {
-                                                                            return action.propertyValue('enabled');
-                                                                          }) : true).then(function (v) { return !!v });
+                               return action.propertyValue('enabled');
+                            }) : true).then(function (v) { return !!v });
+                        },
+                        isHidden: function (selectedItemIds) {                         
+                            return Q(action.hasPropertyValue('hidden') ? invokeProperty(selectedItemIds, function () {
+                                return action.propertyValue('hidden');
+                            }) : false).then(function (v) { return !!v });
                         },
                         actionTarget: actionTarget
                     };
@@ -64,10 +69,18 @@ module.exports = function (entityDescriptionService, injection, appUtil) {
                     return {
                         id: action.id,
                         name: action.name,
-                        isEnabled: isEnabled
+                        isEnabled: isEnabled,
+                        action: action,
                     }
+                }).then(function (actionWrapper) {
+                    return actionWrapper.action.isHidden(selectedItemIds).then(function (isHidden) {
+                        actionWrapper.isHidden = isHidden;
+                        return actionWrapper;
+                    });
                 });
-            }));
+            })).then(function (actions) {
+                return actions.filter(function (action) {return !action.isHidden});
+            });
         },
         performAction: function (entityCrudId, actionId, selectedItemIds) {
             var action = _.find(entityDescriptionService.entityDescription(entityCrudId).actions, function (action) { //TODO permission filtering


### PR DESCRIPTION
Now it is possible to hide entity action basing on current entity object properties.

Sample code using this feature (action will be hidden when status of current entity equals 'Status1':
```
actions: [
            {
              id: 'cancel',
              name: 'Cancel',
              actionTarget: 'single-item',
              perform: function (Crud, Actions,) {
                ...
              },
              hidden: function (Crud, Actions) {
                var crud = Crud.crudForEntityType('SampleEntity');                
                return crud.readEntity(Actions.selectedEntityId()).then(function (entity) {
                  return entity.status == 'Status1' ? true: false;                  
                })
              },
            }
]
```